### PR TITLE
UTC Bug fix

### DIFF
--- a/src/date.js
+++ b/src/date.js
@@ -291,6 +291,8 @@ timezoneJS.Date.prototype = {
   setTimezone: function (tz) {
     if (tz == 'Etc/UTC' || tz == 'Etc/GMT') {
       this.utc = true;
+    } else {
+      this.utc = false;
     }
     this.timezone = tz;
     this._useCache = false;


### PR DESCRIPTION
Bug fix: When initializing a timezoneJS.Date with timezone 'Etc/UTC' and then changing the timezone with timezoneJS.Date.setTimezone(), the timezone offset for the new timezone would be ignored, effectively leaving it to remain at 0."
