### PR TITLE
Only reading index properties of the rules array

### DIFF
--- a/src/date.js
+++ b/src/date.js
@@ -564,7 +564,7 @@ timezoneJS.timezone = new function() {
     {
       var applicableRules = [];
 
-      for ( var i in ruleset )
+      for (var i = 0; i < ruleset.length; i++)
       {
         if ( Number( ruleset[ i ][ 0 ] ) <= year ) // Exclude future rules.
         {
@@ -827,5 +827,3 @@ timezoneJS.timezone = new function() {
     return { tzOffset: off, tzAbbr: abbr };
   }
 }
-
-


### PR DESCRIPTION
Some libraries extend native arrays with additional properties, causing `for (var i in arr)` loops to iterate of non-index properties and in my case (with Ember.js) causing obscure errors.

Using explicit indices in the for loop fixed my issue.
