### PR TITLE
Fix for latest jQuery $.ajax requires dataType for text content.

### DIFF
--- a/src/date.js
+++ b/src/date.js
@@ -133,6 +133,7 @@
     })
     : $.ajax({
       url : opts.url,
+      dataType: 'text',
       method : 'GET',
       error : opts.error,
       success : opts.success


### PR DESCRIPTION
The $.ajax requires the dataType be set to `'text'` in order for the files to be transferred correctly in the `timezoneJS.init()` call.

I don't believe this will affect previous versions of jQuery, but you should probably double check.
