### PR TITLE
setHours, setFullYear and UTC counterparts should accept optional parameters

### DIFF
--- a/spec/date.spec.js
+++ b/spec/date.spec.js
@@ -273,4 +273,46 @@ describe('timezoneJS.Date', function () {
     expect(date.getMonth()).toEqual(1);
     expect(date.getDate()).toEqual(1);
   });
+
+  it("accepts an optional parameter for minutes in setUTCHours", function() {
+    var date = new timezoneJS.Date(2000, 11, 31, 0, 0, 0, "Etc/UTC");
+    expect(date.getUTCMinutes()).toEqual(0);
+    date.setUTCHours(0, 1);
+    expect(date.getUTCMinutes()).toEqual(1);
+  });
+
+  it("accepts a second optional parameter for seconds in setUTCHours", function() {
+    var date = new timezoneJS.Date(2000, 11, 31, 0, 0, 0, "Etc/UTC");
+    expect(date.getUTCSeconds()).toEqual(0);
+    date.setUTCHours(0, 1, 2);
+    expect(date.getUTCSeconds()).toEqual(2);
+  });
+
+  it("accepts an optional parameter for minutes in setUTCHours", function() {
+    var date = new timezoneJS.Date(2000, 11, 31, 0, 0, 0, "Etc/UTC");
+    expect(date.getUTCMilliseconds()).toEqual(0);
+    date.setUTCHours(0, 1, 2, 3);
+    expect(date.getUTCMilliseconds()).toEqual(3);
+  });
+
+  it("accepts an optional parameter for minutes in setHours", function() {
+    var date = new timezoneJS.Date(2000, 11, 31, 0, 0, 0, "America/New_York");
+    expect(date.getMinutes()).toEqual(0);
+    date.setHours(0, 1);
+    expect(date.getMinutes()).toEqual(1);
+  });
+
+  it("accepts a second optional parameter for seconds in setHours", function() {
+    var date = new timezoneJS.Date(2000, 11, 31, 0, 0, 0, "America/New_York");
+    expect(date.getSeconds()).toEqual(0);
+    date.setHours(0, 1, 2);
+    expect(date.getSeconds()).toEqual(2);
+  });
+
+  it("accepts an optional parameter for minutes in setHours", function() {
+    var date = new timezoneJS.Date(2000, 11, 31, 0, 0, 0, "America/New_York");
+    expect(date.getMilliseconds()).toEqual(0);
+    date.setHours(0, 1, 2, 3);
+    expect(date.getMilliseconds()).toEqual(3);
+  });
 });

--- a/src/date.js
+++ b/src/date.js
@@ -264,7 +264,12 @@
     },
     setMonth: function (n) { this.setAttribute('month', n); },
     setYear: function (n) { this.setUTCAttribute('year', n); },
-    setHours: function (n) { this.setAttribute('hours', n); },
+    setHours: function (hours, minutes, seconds, milliseconds) {
+      this.setAttribute('hours', hours);
+      if (minutes) { this.setAttribute('minutes', minutes); }
+      if (seconds) { this.setAttribute('seconds', seconds); }
+      if (milliseconds) { this.setAttribute('milliseconds', milliseconds); }
+    },
     setMilliseconds: function (n) { this.setAttribute('milliseconds', n); },
     setMinutes: function (n) { this.setAttribute('minutes', n); },
     setSeconds: function (n) { this.setAttribute('seconds', n); },
@@ -279,7 +284,12 @@
       if (month !== undefined) { this.setUTCAttribute('month', month); }
       if (date !== undefined) { this.setUTCAttribute('date', date); }
     },
-    setUTCHours: function (n) { this.setUTCAttribute('hours', n); },
+    setUTCHours: function (hours, minutes, seconds, milliseconds) {
+      this.setUTCAttribute('hours', hours);
+      if (minutes) { this.setUTCAttribute('minutes', minutes); }
+      if (seconds) { this.setUTCAttribute('seconds', seconds); }
+      if (milliseconds) { this.setUTCAttribute('milliseconds', milliseconds); }
+    },
     setUTCMilliseconds: function (n) { this.setUTCAttribute('milliseconds', n); },
     setUTCMinutes: function (n) { this.setUTCAttribute('minutes', n); },
     setUTCMonth: function (n) { this.setUTCAttribute('month', n); },


### PR DESCRIPTION
Fixes https://github.com/mde/timezone-js/issues/48
