### PR TITLE
Made all the set* and get* functions work to the Date spec.

### DIFF
--- a/spec/date.spec.js
+++ b/spec/date.spec.js
@@ -234,6 +234,7 @@ describe('timezoneJS.Date', function () {
     expect(dt.getTime()).toEqual(t);
   });
 
+  // Years
   it("accepts an optional parameter for month in setUTCFullYear", function() {
     var date = new timezoneJS.Date(2000, 11, 31, 0, 0, 0, "Etc/UTC");
     expect(date.getUTCMonth()).toEqual(11);
@@ -274,25 +275,57 @@ describe('timezoneJS.Date', function () {
     expect(date.getDate()).toEqual(1);
   });
 
+  // Months
+  it("accepts an optional parameter for date in setUTCMonths", function() {
+    var date = new timezoneJS.Date(2000, 7, 14, 0, 0, 0, "Etc/UTC");
+    expect(date.getUTCMonth()).toEqual(7);
+    expect(date.getUTCDate()).toEqual(14);
+    date.setUTCMonth(1, 5);
+    expect(date.getUTCMonth()).toEqual(1);
+    expect(date.getUTCDate()).toEqual(5);
+    date.setUTCMonth(0, 0);
+    expect(date.getUTCMonth()).toEqual(11);
+    expect(date.getUTCDate()).toEqual(31);
+  });
+
+  it("accepts an optional parameter for date in setMonths", function() {
+    var date = new timezoneJS.Date(2000, 7, 14, 0, 0, 0, "America/New_York");
+    expect(date.getMonth()).toEqual(7);
+    expect(date.getDate()).toEqual(14);
+    date.setMonth(1, 5);
+    expect(date.getMonth()).toEqual(1);
+    expect(date.getDate()).toEqual(5);
+    date.setMonth(0, 0);
+    expect(date.getMonth()).toEqual(11);
+    expect(date.getDate()).toEqual(31);
+  });
+
+  // Hours
   it("accepts an optional parameter for minutes in setUTCHours", function() {
     var date = new timezoneJS.Date(2000, 11, 31, 0, 0, 0, "Etc/UTC");
     expect(date.getUTCMinutes()).toEqual(0);
     date.setUTCHours(0, 1);
     expect(date.getUTCMinutes()).toEqual(1);
+    date.setUTCHours(0, 0);
+    expect(date.getUTCMinutes()).toEqual(0);
   });
 
-  it("accepts a second optional parameter for seconds in setUTCHours", function() {
+  it("accepts an optional parameter for seconds in setUTCHours", function() {
     var date = new timezoneJS.Date(2000, 11, 31, 0, 0, 0, "Etc/UTC");
     expect(date.getUTCSeconds()).toEqual(0);
     date.setUTCHours(0, 1, 2);
     expect(date.getUTCSeconds()).toEqual(2);
+    date.setUTCHours(0, 0, 0);
+    expect(date.getUTCSeconds()).toEqual(0);
   });
 
-  it("accepts an optional parameter for minutes in setUTCHours", function() {
+  it("accepts an optional parameter for milliseconds in setUTCHours", function() {
     var date = new timezoneJS.Date(2000, 11, 31, 0, 0, 0, "Etc/UTC");
     expect(date.getUTCMilliseconds()).toEqual(0);
     date.setUTCHours(0, 1, 2, 3);
     expect(date.getUTCMilliseconds()).toEqual(3);
+    date.setUTCHours(0, 0, 0, 0);
+    expect(date.getUTCMilliseconds()).toEqual(0);
   });
 
   it("accepts an optional parameter for minutes in setHours", function() {
@@ -300,25 +333,134 @@ describe('timezoneJS.Date', function () {
     expect(date.getMinutes()).toEqual(0);
     date.setHours(0, 1);
     expect(date.getMinutes()).toEqual(1);
+    date.setHours(0, 0);
+    expect(date.getMinutes()).toEqual(0);
   });
 
-  it("accepts a second optional parameter for seconds in setHours", function() {
+  it("accepts an optional parameter for seconds in setHours", function() {
     var date = new timezoneJS.Date(2000, 11, 31, 0, 0, 0, "America/New_York");
     expect(date.getSeconds()).toEqual(0);
     date.setHours(0, 1, 2);
     expect(date.getSeconds()).toEqual(2);
+    date.setHours(0, 0, 0);
+    expect(date.getSeconds()).toEqual(0);
   });
 
-  it("accepts an optional parameter for minutes in setHours", function() {
+  it("accepts an optional parameter for milliseconds in setHours", function() {
     var date = new timezoneJS.Date(2000, 11, 31, 0, 0, 0, "America/New_York");
     expect(date.getMilliseconds()).toEqual(0);
     date.setHours(0, 1, 2, 3);
     expect(date.getMilliseconds()).toEqual(3);
+    date.setHours(0, 0, 0, 0);
+    expect(date.getMilliseconds()).toEqual(0);
   });
-  
-  it("Handles static dst offsets in Zones like '1:00' instead of DST rule references.", function(){
+
+  // Minutes
+  it("accepts an optional parameter for seconds in setUTCMinutes", function() {
+    var date = new timezoneJS.Date(2000, 11, 31, 0, 0, 0, "Etc/UTC");
+    expect(date.getUTCSeconds()).toEqual(0);
+    date.setUTCMinutes(0, 1);
+    expect(date.getUTCSeconds()).toEqual(1);
+    date.setUTCMinutes(0, 0);
+    expect(date.getUTCSeconds()).toEqual(0);
+  });
+
+  it("accepts an optional parameter for milliseconds in setUTCMinutes", function() {
+    var date = new timezoneJS.Date(2000, 11, 31, 0, 0, 0, "Etc/UTC");
+    expect(date.getUTCMilliseconds()).toEqual(0);
+    date.setUTCMinutes(0, 1, 2);
+    expect(date.getUTCMilliseconds()).toEqual(2);
+    date.setUTCMinutes(0, 0, 0);
+    expect(date.getUTCMilliseconds()).toEqual(0);
+  });
+
+  it("accepts an optional parameter for seconds in setMinutes", function() {
+    var date = new timezoneJS.Date(2000, 11, 31, 0, 0, 0, "America/New_York");
+    expect(date.getSeconds()).toEqual(0);
+    date.setMinutes(0, 1);
+    expect(date.getSeconds()).toEqual(1);
+    date.setMinutes(0, 0);
+    expect(date.getSeconds()).toEqual(0);
+  });
+
+  it("accepts an optional parameter for milliseconds in setMinutes", function() {
+    var date = new timezoneJS.Date(2000, 11, 31, 0, 0, 0, "America/New_York");
+    expect(date.getMilliseconds()).toEqual(0);
+    date.setMinutes(0, 1, 2);
+    expect(date.getMilliseconds()).toEqual(2);
+    date.setMinutes(0, 0, 0);
+    expect(date.getMilliseconds()).toEqual(0);
+  });
+
+  // Seconds
+  it("accepts an optional parameter for milliseconds in setUTCSeconds", function() {
+    var date = new timezoneJS.Date(2000, 11, 31, 0, 0, 0, "Etc/UTC");
+    expect(date.getUTCMilliseconds()).toEqual(0);
+    date.setUTCSeconds(0, 1);
+    expect(date.getUTCMilliseconds()).toEqual(1);
+    date.setUTCSeconds(0, 0);
+    expect(date.getUTCMilliseconds()).toEqual(0);
+  });
+
+  it("accepts an optional parameter for milliseconds in setSeconds", function() {
+    var date = new timezoneJS.Date(2000, 11, 31, 0, 0, 0, "America/New_York");
+    expect(date.getMilliseconds()).toEqual(0);
+    date.setSeconds(0, 1);
+    expect(date.getMilliseconds()).toEqual(1);
+    date.setSeconds(0, 0);
+    expect(date.getMilliseconds()).toEqual(0);
+  });
+
+
+  it("handles static dst offsets in Zones like '1:00' instead of DST rule references.", function(){
     var date = new timezoneJS.Date(Date.UTC(2012, 2, 1, 0, 0, 0, 0), "Pacific/Apia");
     expect(date.getTimezoneOffset()).toBe(-840);
     expect(date.toString("yyyy-MM-dd HH:mm:ss Z")).toBe("2012-03-01 14:00:00 WSDT");
+  });
+
+  it("returns the milis value for setTime", function() {
+    var date = new timezoneJS.Date("America/New_York");
+    expect(date.setTime(123456789)).toEqual(123456789);
+  });
+
+  it("returns the milis value for every set* command", function() {
+    milis = 1193851822000
+    var date = new timezoneJS.Date(milis, "America/New_York");
+    expect(date.setFullYear(date.getFullYear())).toEqual(milis);
+    expect(date.setMonth(date.getMonth())).toEqual(milis);
+    expect(date.setDate(date.getDate())).toEqual(milis);
+    expect(date.setHours(date.getHours())).toEqual(milis);
+    expect(date.setMinutes(date.getMinutes())).toEqual(milis);
+    expect(date.setSeconds(date.getSeconds())).toEqual(milis);
+    expect(date.setMilliseconds(date.getMilliseconds())).toEqual(milis);
+  });
+
+  it("returns the milis value for every setUTC* command", function() {
+    milis = 1193851822000
+    var date = new timezoneJS.Date(milis, "America/New_York");
+    expect(date.setUTCFullYear(date.getUTCFullYear())).toEqual(milis);
+    expect(date.setUTCMonth(date.getUTCMonth())).toEqual(milis);
+    expect(date.setUTCDate(date.getUTCDate())).toEqual(milis);
+    expect(date.setUTCHours(date.getUTCHours())).toEqual(milis);
+    expect(date.setUTCMinutes(date.getUTCMinutes())).toEqual(milis);
+    expect(date.setUTCSeconds(date.getUTCSeconds())).toEqual(milis);
+    expect(date.setUTCMilliseconds(date.getUTCMilliseconds())).toEqual(milis);
+  });
+
+  it("handles getYear appropriately strangely (to spec)", function() {
+    // http://www.ecma-international.org/ecma-262/5.1/#sec-B.2.4
+    var date = new timezoneJS.Date(1998, 11, 31, 0, 0, 0, "America/New_York");
+    expect(date.getYear()).toEqual(98);
+    date.setFullYear(2013);
+    expect(date.getYear()).toEqual(113);
+  });
+
+  it("handles setYear appropriately strangely (to spec)", function() {
+    // http://www.ecma-international.org/ecma-262/5.1/#sec-B.2.5
+    var date = new timezoneJS.Date(2001, 11, 31, 0, 0, 0, "America/New_York");
+    date.setYear(98)
+    expect(date.getFullYear()).toEqual(1998);
+    date.setYear(2003);
+    expect(date.getFullYear()).toEqual(2003);
   });
 });

--- a/src/date.js
+++ b/src/date.js
@@ -213,7 +213,7 @@
     getDay: function () { return this._day; },
     getFullYear: function () { return this.year; },
     getMonth: function () { return this.month; },
-    getYear: function () { return this.year; },
+    getYear: function () { return this.year - 1900; },
     getHours: function () { return this.hours; },
     getMilliseconds: function () { return this.milliseconds; },
     getMinutes: function () { return this.minutes; },
@@ -255,45 +255,93 @@
       dt.setUTCMinutes(dt.getUTCMinutes() + this.getTimezoneOffset());
       return dt;
     },
-    setDate: function (n) { this.setAttribute('date', n); },
+    setDate: function (date) {
+      this.setAttribute('date', date);
+      return this.getTime();
+    },
     setFullYear: function (year, month, date) {
       if (date !== undefined) { this.setAttribute('date', 1); }
       this.setAttribute('year', year);
       if (month !== undefined) { this.setAttribute('month', month); }
       if (date !== undefined) { this.setAttribute('date', date); }
+      return this.getTime();
     },
-    setMonth: function (n) { this.setAttribute('month', n); },
-    setYear: function (n) { this.setUTCAttribute('year', n); },
+    setMonth: function (month, date) {
+      this.setAttribute('month', month);
+      if (date !== undefined) { this.setAttribute('date', date); }
+      return this.getTime();
+    },
+    setYear: function (year) {
+      year = Number(year);
+      if (0 <= year && year <= 99) { year += 1900; }
+      this.setUTCAttribute('year', year);
+      return this.getTime();
+    },
     setHours: function (hours, minutes, seconds, milliseconds) {
       this.setAttribute('hours', hours);
-      if (minutes) { this.setAttribute('minutes', minutes); }
-      if (seconds) { this.setAttribute('seconds', seconds); }
-      if (milliseconds) { this.setAttribute('milliseconds', milliseconds); }
+      if (minutes !== undefined) { this.setAttribute('minutes', minutes); }
+      if (seconds !== undefined) { this.setAttribute('seconds', seconds); }
+      if (milliseconds !== undefined) { this.setAttribute('milliseconds', milliseconds); }
+      return this.getTime();
     },
-    setMilliseconds: function (n) { this.setAttribute('milliseconds', n); },
-    setMinutes: function (n) { this.setAttribute('minutes', n); },
-    setSeconds: function (n) { this.setAttribute('seconds', n); },
+    setMinutes: function (minutes, seconds, milliseconds) {
+      this.setAttribute('minutes', minutes);
+      if (seconds !== undefined) { this.setAttribute('seconds', seconds); }
+      if (milliseconds !== undefined) { this.setAttribute('milliseconds', milliseconds); }
+      return this.getTime();
+    },
+    setSeconds: function (seconds, milliseconds) {
+      this.setAttribute('seconds', seconds);
+      if (milliseconds !== undefined) { this.setAttribute('milliseconds', milliseconds); }
+      return this.getTime();
+    },
+    setMilliseconds: function (milliseconds) {
+      this.setAttribute('milliseconds', milliseconds);
+      return this.getTime();
+    },
     setTime: function (n) {
       if (isNaN(n)) { throw new Error('Units must be a number.'); }
       this.setFromTimeProxy(n, this.timezone);
+      return this.getTime();
     },
-    setUTCDate: function (n) { this.setUTCAttribute('date', n); },
     setUTCFullYear: function (year, month, date) {
       if (date !== undefined) { this.setUTCAttribute('date', 1); }
       this.setUTCAttribute('year', year);
       if (month !== undefined) { this.setUTCAttribute('month', month); }
       if (date !== undefined) { this.setUTCAttribute('date', date); }
+      return this.getTime();
+    },
+    setUTCMonth: function (month, date) {
+      this.setUTCAttribute('month', month);
+      if (date !== undefined) { this.setUTCAttribute('date', date); }
+      return this.getTime();
+    },
+    setUTCDate: function (date) {
+      this.setUTCAttribute('date', date);
+      return this.getTime();
     },
     setUTCHours: function (hours, minutes, seconds, milliseconds) {
       this.setUTCAttribute('hours', hours);
-      if (minutes) { this.setUTCAttribute('minutes', minutes); }
-      if (seconds) { this.setUTCAttribute('seconds', seconds); }
-      if (milliseconds) { this.setUTCAttribute('milliseconds', milliseconds); }
+      if (minutes !== undefined) { this.setUTCAttribute('minutes', minutes); }
+      if (seconds !== undefined) { this.setUTCAttribute('seconds', seconds); }
+      if (milliseconds !== undefined) { this.setUTCAttribute('milliseconds', milliseconds); }
+      return this.getTime();
     },
-    setUTCMilliseconds: function (n) { this.setUTCAttribute('milliseconds', n); },
-    setUTCMinutes: function (n) { this.setUTCAttribute('minutes', n); },
-    setUTCMonth: function (n) { this.setUTCAttribute('month', n); },
-    setUTCSeconds: function (n) { this.setUTCAttribute('seconds', n); },
+    setUTCMinutes: function (minutes, seconds, milliseconds) {
+      this.setUTCAttribute('minutes', minutes);
+      if (seconds !== undefined) { this.setUTCAttribute('seconds', seconds); }
+      if (milliseconds !== undefined) { this.setUTCAttribute('milliseconds', milliseconds); }
+      return this.getTime();
+    },
+    setUTCSeconds: function (seconds, milliseconds) {
+      this.setUTCAttribute('seconds', seconds);
+      if (milliseconds !== undefined) { this.setUTCAttribute('milliseconds', milliseconds); }
+      return this.getTime();
+    },
+    setUTCMilliseconds: function (milliseconds) {
+      this.setUTCAttribute('milliseconds', milliseconds);
+      return this.getTime();
+    },
     setFromDateObjProxy: function (dt) {
       this.year = dt.getFullYear();
       this.month = dt.getMonth();
@@ -302,7 +350,7 @@
       this.minutes = dt.getMinutes();
       this.seconds = dt.getSeconds();
       this.milliseconds = dt.getMilliseconds();
-      this._day =  dt.getDay();
+      this._day = dt.getDay();
       this._dateProxy = dt;
       this._timeProxy = Date.UTC(this.year, this.month, this.date, this.hours, this.minutes, this.seconds, this.milliseconds);
       this._useCache = false;
@@ -540,7 +588,7 @@
       var date = typeof dt === 'number' ? new Date(dt) : dt;
       var ruleset = zone[1];
       var basicOffset = zone[0];
-      
+
       // If the zone has a DST rule like '1:00', create a rule and return it
       // instead of looking it up in the parsed rules
       var staticDstMatch = ruleset.match(/^([0-9]):([0-9][0-9])$/);


### PR DESCRIPTION
Wrote the unit tests to test against http://www.ecma-international.org/ecma-262/5.1 and then changed the functions to follow the spec. Pretty much every set\* or get\* function was changed in the process. All changes except the ones to get/setYear are backwards compatible to the API that was there before.

This closes this issue: https://github.com/mde/timezone-js/issues/48
