### PR TITLE
TimezoneJS should be a little bit more robust when test frameworks wrap the Date constructor.

### DIFF
--- a/src/date.js
+++ b/src/date.js
@@ -746,7 +746,7 @@
 
       var compareDates = function (a, b, prev) {
         var year, rule;
-        if (a.constructor !== Date) {
+        if (!(a instanceof Date)) {
           year = a[0];
           rule = a[1];
           a = (!prev && EXACT_DATE_TIME[year] && EXACT_DATE_TIME[year][rule])
@@ -755,7 +755,7 @@
         } else if (prev) {
           a = convertDateToUTC(a, isUTC ? 'u' : 'w', prev);
         }
-        if (b.constructor !== Date) {
+        if (!(b instanceof Date)) {
           year = b[0];
           rule = b[1];
           b = (!prev && EXACT_DATE_TIME[year] && EXACT_DATE_TIME[year][rule]) ? EXACT_DATE_TIME[year][rule]


### PR DESCRIPTION
No longer failing to detect dates when test frameworks overwrite the Date constructor (poorly)

Specifically, SinonJS overwrites the Date constructor with a function that produces date objects
whose constructor property is the original Date constructor, while Date currently refers to the Sinon wrapper.

That hullabaloo makes a.constructor !== Date end up true when it should be false.
