### PR TITLE
fix bug with date strings without timezone

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,23 @@ If you use `timezoneJS.Date` with `Fleegix.js`, there's nothing else you need to
 
 ## Usage
 
+The `timezoneJS.Date` constructor is compatible to the normal JavaScript Date constructor, but additional allows to pass an optional `tz` (timezone). In the following cases the passed date/time is unambiguous:
+
+    timezoneJS.Date(millis, [tz])
+    timezoneJS.Date(Date, [tz])
+    timezoneJS.Date(dt_str_tz, [tz])
+
+`dt_str_tz` is a date string containing timezone information, i.e. containing 'Z', 'T' or a timezone offset matching the regular expression /[+-][0-9]{4}/ (e.g. '+0200'). The [one-stop shop for cross-browser JavaScript Date parsing behavior](http://dygraphs.com/date-formats.html) provides detailed information about JavaScript date formats.
+
+In the following cases the date is assumed to be a date in timezone `tz` or a locale date if `tz` is not provided:
+
+    timezoneJS.Date(year, mon, day, [hour], [min], [second], [tz])
+    timezoneJS.Date(dt_str, [tz])
+
+`dt_str_tz` is a date string containing no timezone information.
+
+### Examples
+
 Create a `timezoneJS.Date` the same way as a normal JavaScript Date, but append a timezone parameter on the end:
 
 	var dt = new timezoneJS.Date('10/31/2008', 'America/New_York');

--- a/spec/date.spec.js
+++ b/spec/date.spec.js
@@ -157,6 +157,18 @@ describe('timezoneJS.Date', function () {
 
   });
 
+  it('should take in String (other format) and Etc/UTC as constructor', function () {
+    var dt = new timezoneJS.Date('2013/06/18 10:37', 'Etc/UTC');
+
+    expect(dt.toString('yyyy/MM/dd HH:mm', 'America/Los_Angeles')).toEqual('2013/06/18 03:37');
+  });
+
+  it('should take in String (other format) and Europe/Athens as constructor', function () {
+    var dt = new timezoneJS.Date('2013/06/18 10:37', 'Europe/Athens');
+
+    expect(dt.toString('yyyy/MM/dd HH:mm', 'America/Los_Angeles')).toEqual('2013/06/18 00:37');
+  });
+
   it('should take in String as constructor', function () {
     var dtA = new Date()
     , dt = new timezoneJS.Date(dtA.toJSON());


### PR DESCRIPTION
Example:
    document.write(new timezoneJS.Date('05/29/2013 09:25', 'Europe/London'))
Expected output independent of client's timezone:
    2013-05-29 09:25:00
Output without this fix:
    [date/time in timezone `tz`, where `dt` is interpreted in client's timezone]

Note: without this fix, it is not possible to get a unix timestamp, if
the only available information is a datestring and a timezone string
(e.g. 'Europe/London').
