### PR TITLE
Fix bug where exception is thrown if rule is null

### DIFF
--- a/spec/date.spec.js
+++ b/spec/date.spec.js
@@ -44,6 +44,11 @@ describe('timezoneJS.Date', function () {
     expect(date.toString('MMM dd yyyy HH:mm:ss k Z', 'Indian/Cocos')).toEqual('Feb 28 2011 07:14:22 PM CCT');
   });
 
+  it('should format the Unix Epoch UTC to different formats and tz correctly', function () {
+    var date = new timezoneJS.Date(1970,0,1,0,0,0,0,'Etc/UTC');
+    expect(date.toString('MMM dd yyyy HH:mm:ss k Z', 'Europe/Kaliningrad')).toEqual('Jan 01 1970 03:00:00 AM MSK');
+  });
+
   it('should use a default format with the given tz', function () {
     var date = new timezoneJS.Date(2012, 7, 30, 10, 56, 0, 0, 'America/Los_Angeles');
     expect(date.toString(null, 'Etc/UTC')).toEqual(date.toString('yyyy-MM-dd HH:mm:ss', 'Etc/UTC'));

--- a/src/date.js
+++ b/src/date.js
@@ -838,7 +838,7 @@
         return base.replace('%s', repl);
       } else if (base.indexOf('/') > -1) {
         //Chose one of two alternative strings.
-        return base.split("/", 2)[rule[6] ? 1 : 0];
+        return base.split("/", 2)[rule ? (rule[6] ? 1 : 0) : 0];
       }
       return base;
     }


### PR DESCRIPTION
I ran into this error when using the "Europe/Kaliningrad" timezone, though I don't see why. For timestamps before a certain date (somewhere around 1980), `getAbbreviation` throws an exception because it tries to access `rule[6]` when `rule` is `null`. You can confirm this by running the spec I added without the patch to `date.js`.

@longlho Let me know if this patch makes sense to you.
