### PR TITLE
greater flexibility and protection when exporting timezoneJS

### DIFF
--- a/src/date.js
+++ b/src/date.js
@@ -40,11 +40,15 @@
   "use strict";
   var root = this;
 
-  var timezoneJS;
+  // Export the timezoneJS object for Node.js, with backwards-compatibility for the old `require()` API
+  var timezoneJS = {};
   if (typeof exports !== 'undefined') {
-    timezoneJS = exports;
+    if (typeof module !== 'undefined' && module.exports) {
+      exports = module.exports = timezoneJS;
+    }
+    exports.timezoneJS = timezoneJS;
   } else {
-    timezoneJS = root.timezoneJS = {};
+    root.timezoneJS = timezoneJS;
   }
 
   timezoneJS.VERSION = '0.4.4';


### PR DESCRIPTION
The current method for exporting doesn't play well with some other less-friendly libraries. This can cause things like infinite recursion and all sorts of pain.

Specific library causing me problems: https://github.com/bytespider/jsOAuth
jsOAuth does this:

```
var exports = exports || this;
exports.OAuth = (function (global) {
...
```

In the browser, the problem here is that `exports` is now `window`. timezoneJS then comes along and does this:

```
timezoneJS = exports; // equivalent to `timezoneJS = window;`
...
timezoneJS.Date = ...; // equivalent to `window.Date = ...;`
```

Then, any time you try to create a timezoneJS.Date object it invokes `new Date(...)` which is equivalent to calling `timezoneJS.Date(...)` -- you see the problem this creates.

So I adapted the export pattern used by timezoneJS to follow the pattern used by underscore.js which also accounts for `module` and the problems went away. The tests all still pass for me in node@v0.10.12 and it also works in harmony with jsOAuth and other modules that blindly muck around with the global `exports` object.
