### PR TITLE
Ignore README file when parsing Oslon files

### DIFF
--- a/src/node-preparse.js
+++ b/src/node-preparse.js
@@ -2,7 +2,7 @@
 
   var fs = require('fs')
   , timezoneJS = require('./date')
-  , EXCLUDED = new RegExp('Makefile|factory|(\\.+)', 'i');
+  , EXCLUDED = new RegExp('README|Makefile|factory|(\\.+)', 'i');
 
   function parse(args) {
     // Upgrade passed script args to real Array


### PR DESCRIPTION
A README file was added to the Olson file archives. Add it to the
EXCLUDED list so node-preparse.js doesn't attempt to parse it and crash.
