### PR TITLE
Turn numbers into strings when stringifying the timezone data.

### DIFF
--- a/src/node-preparse.js
+++ b/src/node-preparse.js
@@ -48,7 +48,12 @@
       result.zones = _tz.zones;
       result.rules = _tz.rules;
     }
-    console.log(JSON.stringify(result));
+    console.log(JSON.stringify(result, function(key, value) {
+      if (typeof(value) == "number") {
+        return value.toString()
+      }
+      return value
+    }));
   }
 
   module.exports = parse(process.argv);


### PR DESCRIPTION
When trying to create prebuilt JSON using the IANA files, the africa file was yielding integers for zone data, i.e.  

{"Africa/Algiers":[[-12.2,"-","LMT",-2486678340000], ... ] }

instead of

{"Africa/Algiers":[["-12.2","-","LMT","-2486678340000"], ... ] }

Various functions throughout this library depend on these values being strings.  This PR turns any numbers into strings when stringifying.
