### PR TITLE
getUTCDateProxy sometimes returns 'Invalid Date'

### DIFF
--- a/src/date.js
+++ b/src/date.js
@@ -318,7 +318,7 @@
     },
     getUTCDateProxy: function () {
       var dt = new Date(this._timeProxy);
-      dt.setUTCMinutes(dt.getUTCMinutes() + this.getTimezoneOffset());
+      dt.setUTCMinutes(parseInt(dt.getUTCMinutes()) + parseInt(this.getTimezoneOffset()));
       return dt;
     },
     setDate: function (date) {


### PR DESCRIPTION
When using pre-parsed JSON data, some timezones were returning
getUTCMinutes and getTimezoneOffset as a string (e.g. "30-60").
