### PR TITLE
Fix Incorrect "Link" parsing

### DIFF
--- a/src/date.js
+++ b/src/date.js
@@ -1020,11 +1020,11 @@
               //Links are saved as strings that are the keys
               //of their referenced values.
               //Ex: "US/Central": "America/Chicago"
-              if (isNaN(parseInt(arr[0]))) {
+              if (isNaN(arr[0])) {
                 _this.zones[arr[1]] = arr[0];
               }
               else {
-                _this.zones[arr[1]] = parseInt(arr[0]);
+                _this.zones[arr[1]] = parseInt(arr[0], 10);
               }
               break;
           }


### PR DESCRIPTION
The parser was trying to treat the "Link" values as a number. By casting the strings (the desired type) to a number, the result became "NaN" (the string). This should clear it up.
