### PR TITLE
Use window if 'this' is not defined when using browserify 'require' function

### DIFF
--- a/src/date.js
+++ b/src/date.js
@@ -1058,4 +1058,4 @@
       return { tzOffset: off, tzAbbr: abbr };
     };
   }();
-}).call(this);
+}).call(typeof window !== "undefined" ? window : this);


### PR DESCRIPTION
Signed-off-by: Ryan Chen ryan.chen@turn.com
