### PR TITLE
Ensure default timezone offsets get cast as a Number

### DIFF
--- a/src/date.js
+++ b/src/date.js
@@ -1048,7 +1048,7 @@
         }
       }
       var z = getZone(dt, tz);
-      var off = z[0];
+      var off = +z[0];
       //See if the offset needs adjustment.
       var rule = getRule(dt, z, isUTC);
       if (rule) {


### PR DESCRIPTION
The pre-parsed json data has offsets as a string.  Unfortunately
timezone-js was not casting them to a number so in many cases the new
calculated times were wrong (e.g. 5 + "60" = "560" instead of 65) or
caused NaN errors when passed to date.setUTCMinutes (e.g. 5+"-60" = "5-60").
