### PR TITLE
Add undefined check for jasmine tests

### DIFF
--- a/src/date.js
+++ b/src/date.js
@@ -968,6 +968,11 @@
       return arr.sort();
     };
     this.parseZones = function (str) {
+
+      if (!str) {
+        return false;
+      }
+
       var lines = str.split('\n')
         , arr = []
         , chunk = ''


### PR DESCRIPTION
When using timezone in our project and trying to do unit test, there are errors like:

```
>> TypeError: 'undefined' is not an object (evaluating 'str.split') at
>> build/turn-side-data-filter.js:49562
>> build/turn-side-data-filter.js:49165 builtInLoadZoneFile
>> build/turn-side-data-filter.js:49526
>> build/turn-side-data-filter.js:66235
>> build/turn-side-data-filter.js:66345
>> build/turn-side-data-filter.js:1 s
>> build/turn-side-data-filter.js:1
>> build/turn-side-data-filter.js:63908
>> build/turn-side-data-filter.js:1 s
>> build/turn-side-data-filter.js:1
>> build/turn-side-data-filter.js:67463
>> build/turn-side-data-filter.js:1 s
>> build/turn-side-data-filter.js:1
>> build/turn-side-data-filter.js:92444
>> build/turn-side-data-filter.js:1 s
>> build/turn-side-data-filter.js:1 e
>> build/turn-side-data-filter.js:92547
x
```

Which is due to a missing timezone file during synchronous fetching failure at 

```
var _transport = function (opts) {
    if (!opts) return;
    if (!opts.url) throw new Error ('URL must be specified');
    if (!('async' in opts)) opts.async = true;

    // Server-side (node)
   ...

    // Client-side
   ...
    return fleegix && fleegix.xhr
    ? fleegix.xhr.send({
      url : opts.url,
      method : 'get',
      handleSuccess : opts.success,
      handleErr : opts.error
    })
    : ajax_lib.ajax({
      url : opts.url,
      dataType: 'text',
      method : 'GET',
      error : opts.error,
      success : opts.success
    });
  };
```

The last part `ajax_lib.ajax` triggered and failed. The fix is to add a undefined check to avoid this issue when performing jasmine test on other project, when loading with bower or npm.
