### PR TITLE
V0.4 Fixing daylight saving problems

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,10 +1,12 @@
 {
-  "laxcomma": true,
-  "browser": true,
-  "globalstrict": true,
-  "strict": true,
-  "expr": true,
-  "multistr": true,
+    "node":true,
+	"jquery":true,
+	"browser":true,
+
+	"undef":true,
+	"unused": true,
+	"smarttabs":true,
+	"esnext":true,
   "globals": {
     "define": true,
     "window": true,

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ The other significant difference from the built-in JavaScript Date is that `time
 
 ## Setup
 
+This section shows the most common way of setting up timezone-js. In the 'Customizing' section below you can find alternative approaches.
+
 First you'll need to include the code on your page. Both `timezoneJS.Date`, and the supporting code it needs in `timezoneJS.timezone` are bundled in the `date.js` file in `src` directory. Include the code on your page with a normal JavaScript script include, like so:
 
 	<script type="text/javascript" src="/js/timezone-js/src/date.js">
@@ -24,28 +26,32 @@ Next you'll need the Olson time zone files -- `timezoneJS.Date` uses the raw Ols
 
 Here is an example of how to get the Olson time zone files:
 
-    ##!/bin/bash
-        
-    # NOTE: Run from your webroot
-    
-    # Create the /tz directory
-    mkdir tz
-    
-    # Download the latest Olson files
-    curl ftp://ftp.iana.org/tz/tzdata-latest.tar.gz -o tz/tzdata-latest.tar.gz
-    
-    # Expand the files
-    tar -xvzf tz/tzdata-latest.tar.gz -C tz
+``` bash
+##!/bin/bash
 
-    # Optionally, you can remove the downloaded archives.
-    rm tz/tzdata-latest.tar.gz
+# NOTE: Run from your webroot
+
+# Create the /tz directory
+mkdir tz
+
+# Download the latest Olson files
+curl ftp://ftp.iana.org/tz/tzdata-latest.tar.gz -o tz/tzdata-latest.tar.gz
+
+# Expand the files
+tar -xvzf tz/tzdata-latest.tar.gz -C tz
+
+# Optionally, you can remove the downloaded archives.
+rm tz/tzdata-latest.tar.gz
+```
 
 Then you'll need to make the files available to the `timezoneJS.timezone` code, and initialize the code to parse your default region. (This will be North America if you don't change it). No sense in downloading and parsing timezone data for the entire world if you're not going to be using it.
 
 Put your directory of Olson files somewhere under your Web server root, and point `timezoneJS.timezone.zoneFileBasePath` to it. Then call the init function. Your code will look something like this:
 
-	timezoneJS.timezone.zoneFileBasePath = '/tz';
-	timezoneJS.timezone.init({ callback: cb });
+``` js
+timezoneJS.timezone.zoneFileBasePath = '/tz';
+timezoneJS.timezone.init({ callback: cb });
+```
 
 If you use `timezoneJS.Date` with `Fleegix.js`, `jQuery` or `jQuery`-compatible libraries (like `Zepto.js`), there's nothing else you need to do -- timezones for North America will be loaded and parsed on initial page load, and others will be downloaded and parsed on-the-fly, as needed. If you want to use this code with some other JavaScript toolkit, you'll need to overwrite your own transport method by setting `timezoneJS.timezone.transport = someFunction` method. Take a look at `test-utils.js` in `spec` for an example.
 
@@ -55,16 +61,20 @@ If you use `timezoneJS.Date` with `Fleegix.js`, `jQuery` or `jQuery`-compatible 
 
 The `timezoneJS.Date` constructor is compatible to the normal JavaScript Date constructor, but additional allows to pass an optional `tz` (timezone). In the following cases the passed date/time is unambiguous:
 
-    timezoneJS.Date(millis, [tz])
-    timezoneJS.Date(Date, [tz])
-    timezoneJS.Date(dt_str_tz, [tz])
+``` js
+timezoneJS.Date(millis, [tz])
+timezoneJS.Date(Date, [tz])
+timezoneJS.Date(dt_str_tz, [tz])
+```
 
 `dt_str_tz` is a date string containing timezone information, i.e. containing `Z`, `T` or a timezone offset matching the regular expression `/[+-][0-9]{4}/` (e.g. `+0200`). The [one-stop shop for cross-browser JavaScript Date parsing behavior](http://dygraphs.com/date-formats.html) provides detailed information about JavaScript date formats.
 
 In the following cases the date is assumed to be a date in timezone `tz` or a locale date if `tz` is not provided:
 
-    timezoneJS.Date(year, mon, day, [hour], [min], [second], [tz])
-    timezoneJS.Date(dt_str, [tz])
+``` js
+timezoneJS.Date(year, mon, day, [hour], [min], [second], [tz])
+timezoneJS.Date(dt_str, [tz])
+```
 
 `dt_str` is a date string containing no timezone information.
 
@@ -72,59 +82,74 @@ In the following cases the date is assumed to be a date in timezone `tz` or a lo
 
 Create a `timezoneJS.Date` the same way as a normal JavaScript Date, but append a timezone parameter on the end:
 
-	var dt = new timezoneJS.Date('10/31/2008', 'America/New_York');
-	var dt = new timezoneJS.Date(2008, 9, 31, 11, 45, 'America/Los_Angeles');
+``` js
+var dt = new timezoneJS.Date('10/31/2008', 'America/New_York');
+var dt = new timezoneJS.Date(2008, 9, 31, 11, 45, 'America/Los_Angeles');
+```
 
 Naturally enough, the `getTimezoneOffset` method returns the timezone offset in minutes based on the timezone you set for the date.
 
-	// Pre-DST-leap
-	var dt = new timezoneJS.Date(2006, 9, 29, 1, 59, 'America/Los_Angeles');
-	dt.getTimezoneOffset(); => 420
-	// Post-DST-leap
-	var dt = new timezoneJS.Date(2006, 9, 29, 2, 0, 'America/Los_Angeles');
-	dt.getTimezoneOffset(); => 480
+``` js
+// Pre-DST-leap
+var dt = new timezoneJS.Date(2006, 9, 29, 1, 59, 'America/Los_Angeles');
+dt.getTimezoneOffset(); => 420
+// Post-DST-leap
+var dt = new timezoneJS.Date(2006, 9, 29, 2, 0, 'America/Los_Angeles');
+dt.getTimezoneOffset(); => 480
+```
 
 Just as you'd expect, the `getTime` method gives you the UTC timestamp for the given date:
 
-	var dtA = new timezoneJS.Date(2007, 9, 31, 10, 30, 'America/Los_Angeles');
-	var dtB = new timezoneJS.Date(2007, 9, 31, 12, 30, 'America/Chicago');
-	// Same timestamp
-	dtA.getTime(); => 1193855400000
-	dtB.getTime(); => 1193855400000
+``` js
+var dtA = new timezoneJS.Date(2007, 9, 31, 10, 30, 'America/Los_Angeles');
+var dtB = new timezoneJS.Date(2007, 9, 31, 12, 30, 'America/Chicago');
+// Same timestamp
+dtA.getTime(); => 1193855400000
+dtB.getTime(); => 1193855400000
+```
 
 You can set (or reset) the timezone using the `setTimezone` method:
 
-	var dt = new timezoneJS.Date('10/31/2006', 'America/Juneau');
-	dt.getTimezoneOffset(); => 540
-	dt.setTimezone('America/Chicago');
-	dt.getTimezoneOffset(); => 300
-	dt.setTimezone('Pacific/Honolulu');
-	dt.getTimezoneOffset(); => 600
+``` js
+var dt = new timezoneJS.Date('10/31/2006', 'America/Juneau');
+dt.getTimezoneOffset(); => 540
+dt.setTimezone('America/Chicago');
+dt.getTimezoneOffset(); => 300
+dt.setTimezone('Pacific/Honolulu');
+dt.getTimezoneOffset(); => 600
+```
 
 The `getTimezone` method tells you what timezone a `timezoneJS.Date` is set to:
 
-	var dt = new timezoneJS.Date('12/27/2010', 'Asia/Tokyo');
-	dt.getTimezone(); => 'Asia/Tokyo'
+``` js
+var dt = new timezoneJS.Date('12/27/2010', 'Asia/Tokyo');
+dt.getTimezone(); => 'Asia/Tokyo'
+```
 
 You can use `getTimezoneAbbreviation` method to get timezone abbreviation:
 
-	var dt = new timezoneJS.Date('10/31/2008', 'America/New_York');
-	dt.getTimezoneAbbreviation(); => 'EDT'
+``` js
+var dt = new timezoneJS.Date('10/31/2008', 'America/New_York');
+dt.getTimezoneAbbreviation(); => 'EDT'
+```
 
 ## Customizing
 
 If you don't change it, the timezone region that loads on
  initialization is North America (the Olson 'northamerica' file). To change that to another reqion, set `timezoneJS.timezone.defaultZoneFile` to your desired region, like so:
- 
-	timezoneJS.timezone.zoneFileBasePath = '/tz';
-	timezoneJS.timezone.defaultZoneFile = 'asia';
-	timezoneJS.timezone.init();
+ ``` js
+timezoneJS.timezone.zoneFileBasePath = '/tz';
+timezoneJS.timezone.defaultZoneFile = 'asia';
+timezoneJS.timezone.init();
+```
 
 If you want to preload multiple regions, set it to an array, like this:
 
-	timezoneJS.timezone.zoneFileBasePath = '/tz';
-	timezoneJS.timezone.defaultZoneFile = ['asia', 'backward', 'northamerica', 'southamerica'];
-	timezoneJS.timezone.init();
+``` js
+timezoneJS.timezone.zoneFileBasePath = '/tz';
+timezoneJS.timezone.defaultZoneFile = ['asia', 'backward', 'northamerica', 'southamerica'];
+timezoneJS.timezone.init();
+```
 
 By default the `timezoneJS.Date` timezone code lazy-loads the timezone data files, pulling them down and parsing them only as needed.
 
@@ -135,6 +160,29 @@ You can change this behavior by changing the value of `timezoneJS.timezone.loadi
 1. `timezoneJS.timezone.loadingSchemes.PRELOAD_ALL` -- this will preload all the timezone data files for all reqions up front. This setting would only make sense if you know your users will be using timezones from all around the world, and you prefer taking the up-front load time to the small on-the-fly lag from lazy loading.
 2. `timezoneJS.timezone.loadingSchemes.LAZY_LOAD` -- the default. Loads some amount of data up front, then lazy-loads any other needed timezone data as needed.
 3. `timezoneJS.timezone.loadingSchemes.MANUAL_LOAD` -- Preloads no data, and does no lazy loading. Use this setting if you're loading pre-parsed JSON timezone data.
+
+## Ready-made tzdata NPM modules
+
+If you use NPM, and you want to load the time zone data synchronously, you can use one or more of the tzdata* NPM modules. That way, you do not have to download the IANA zone files manually, you can just run `npm update` to get the latest data.
+
+The [tzdata](https://www.npmjs.com/package/tzdata) module contains all time zones. There are other modules, e.g. [tzdata-northamerica](https://www.npmjs.com/package/tzdata-northamerica) that contain subsets of the zones.
+
+First, install timezone-js and one or more of the tzdata modules.
+```bash
+npm install timezone-js tzdata
+```
+
+Then, initialize timezone-js with the data:
+```javascript
+var timezoneJS = require("timezone-js");
+var tzdata = require("tzdata");
+
+var _tz = timezoneJS.timezone;
+_tz.loadingScheme = _tz.loadingSchemes.MANUAL_LOAD;
+_tz.loadZoneDataFromObject(tzdata);
+
+var dt = new timezoneJS.Date(2006, 9, 29, 1, 59, 'America/Los_Angeles');
+```
 
 ## Pre-Parsed JSON Data
 
@@ -147,32 +195,43 @@ The src directory contains 2 command-line JavaScript scripts that can generate t
 
 Use the script like this:
 
-	rhino preparse.js zoneFileDirectory [exemplarCities] > outputfile.json
+``` bash
+rhino preparse.js zoneFileDirectory [exemplarCities] > outputfile.json
+```
 
 Or:
 
-	node node-preparse.js zoneFileDirectory [exemplarCities] > outputfile.json
+``` bash
+node node-preparse.js zoneFileDirectory [exemplarCities] > outputfile.json
+```
 
 The first parameter is the directory where the script can find the Olson zoneinfo files. The second (optional) param should be a comma-delimited list of timzeone cities to create the JSON data for. If that parameter isn't passed, the script will generate the JSON data for all the files.
 
-	rhino preparse.js olson_files \
-	"Asia/Tokyo, America/New_York, Europe/London" \
-	> major_cities.json
+``` bash
+rhino preparse.js olson_files \
+"Asia/Tokyo, America/New_York, Europe/London" \
+> major_cities.json
 
-	rhino preparse.js olson_files > all_cities.json
+rhino preparse.js olson_files > all_cities.json
+```
+
 Or:
 
-	node node-preparse.js olson_files \
-	"Asia/Tokyo, America/New_York, Europe/London" \
-	> major_cities.json
+``` bash
+node node-preparse.js olson_files \
+"Asia/Tokyo, America/New_York, Europe/London" \
+> major_cities.json
 
-	node node-preparse.js olson_files > all_cities.json
-	
+node node-preparse.js olson_files > all_cities.json
+```
+
 Once you have your file of JSON data, set your loading scheme to `timezoneJS.timezone.loadingSchemes.MANUAL_LOAD`, and load the JSON data with `loadZoneJSONData`, like this:
 
-	var _tz = timezoneJS.timezone;
-	_tz.loadingScheme = _tz.loadingSchemes.MANUAL_LOAD;
-	_tz.loadZoneJSONData('/major_cities.json', true);
+``` js
+var _tz = timezoneJS.timezone;
+_tz.loadingScheme = _tz.loadingSchemes.MANUAL_LOAD;
+_tz.loadZoneJSONData('/major_cities.json', true);
+```
 
 Since the limited set of data will be much smaller than any of the zoneinfo files, and the JSON data is deserialized with `eval` or `JSON.parse`, this method is significantly faster than the default setup. However, it only works if you know beforehand exactly what timezones you want to use.
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "timezone-js",
-  "version": "0.4.13",
+  "version": "0.4.13-1",
   "main": "src/date.js",
   "ignore": [
     "**/.*",

--- a/package.json
+++ b/package.json
@@ -6,11 +6,12 @@
     "Preston Hunt <prestonhunt@gmail.com>",
     "Dov. B Katz <dov.katz@morganstanley.com>",
     "Peter Bergström <pbergstr@mac.com>",
-    "Long Ho <holevietlong@gmail.com> (http://www.longlho.me)"
+    "Long Ho <holevietlong@gmail.com> (http://www.longlho.me)",
+    "Simon Ruetzler <sruetzer@arigo-software.de>"
   ],
   "name": "timezone-js",
   "description": "JavaScript timezone library based on Olson timezone data",
-  "version": "0.4.13",
+  "version": "0.4.13-1",
   "main": "src/date.js",
   "homepage": "https://github.com/mde/timezone-js",
   "repository": {

--- a/spec/date.spec.js
+++ b/spec/date.spec.js
@@ -14,7 +14,7 @@ describe('timezoneJS.Date', function () {
 
   it('should have correct format when initialized', function () {
     var date = new timezoneJS.Date();
-    expect(date.toString()).toMatch(/[\d]{4}(-[\d]{2}){2} ([\d]{2}:){2}[\d]{2}/);
+    expect(date.toString()).toMatch(/[\d]{4}(-[\d]{2}){2}T([\d]{2}:){2}[\d]{2}.[\d]{3}/);
   });
 
   it('should have handled March correctly (not replacing h) when initialized', function () {
@@ -30,7 +30,7 @@ describe('timezoneJS.Date', function () {
   it('should get date correctly from UTC (2011-10-28T12:44:22.172000000)', function () {
     var date = new timezoneJS.Date(2011, 9, 28, 12, 44, 22, 172,'Etc/UTC');
     expect(date.getTime()).toEqual(1319805862172);
-    expect(date.toString()).toEqual('2011-10-28 12:44:22');
+    expect(date.toString()).toEqual('2011-10-28T12:44:22.172');
     expect(date.toString('yyyy-MM-dd')).toEqual('2011-10-28');
   });
 
@@ -61,8 +61,8 @@ describe('timezoneJS.Date', function () {
 
   it('should use a default format with the given tz', function () {
     var date = new timezoneJS.Date(2012, 7, 30, 10, 56, 0, 0, 'America/Los_Angeles');
-    expect(date.toString(null, 'Etc/UTC')).toEqual(date.toString('yyyy-MM-dd HH:mm:ss', 'Etc/UTC'));
-    expect(date.toString(null, 'America/New_York')).toEqual(date.toString('yyyy-MM-dd HH:mm:ss', 'America/New_York'));
+    expect(date.toString(null, 'Etc/UTC')).toEqual(date.toString('yyyy-MM-ddTHH:mm:ss.SSS', 'Etc/UTC'));
+    expect(date.toString(null, 'America/New_York')).toEqual(date.toString('yyyy-MM-ddTHH:mm:ss.SSS', 'America/New_York'));
   });
 
   it('should convert dates from UTC to a timezone correctly', function () {
@@ -86,7 +86,7 @@ describe('timezoneJS.Date', function () {
 
     dtA.setTimezone('America/Chicago');
     expect(dtA.getTime()).toEqual(1193851800000);
-    expect(dtA.toString()).toEqual('2007-10-31 12:30:00');
+    expect(dtA.toString()).toEqual('2007-10-31T12:30:00.000');
   });
 
   it('should convert dates from unix time properly', function () {
@@ -94,7 +94,7 @@ describe('timezoneJS.Date', function () {
 
     dtA.setTimezone('America/Chicago');
     expect(dtA.getTime()).toEqual(1193851800000);
-    expect(dtA.toString()).toEqual('2007-10-31 12:30:00');
+    expect(dtA.toString()).toEqual('2007-10-31T12:30:00.000');
   });
 
   it('should output toISOString correctly', function () {
@@ -159,7 +159,7 @@ describe('timezoneJS.Date', function () {
     //This is a RFC 3339 UTC string format
     var dt = new timezoneJS.Date('2012-01-01T15:00:00.000', 'Asia/Bangkok');
 
-    expect(dt.toString()).toEqual('2012-01-01 22:00:00');
+    expect(dt.toString()).toEqual('2012-01-01T22:00:00.000');
     expect(dt.toString('yyyy-MM-ddTHH:mm:ss.SSS', 'America/New_York')).toEqual('2012-01-01T10:00:00.000');
     expect(dt.toString('yyyy-MM-ddTHH:mm:ss.SSS')).toEqual('2012-01-01T22:00:00.000');
   });
@@ -251,7 +251,7 @@ describe('timezoneJS.Date', function () {
     var dt = new timezoneJS.Date(2011, 11, 29, 23, 59, 59, 'Pacific/Apia');
     var t = dt.getTime() + 1000;
     dt.setTime(t);
-    expect(dt.toString()).toEqual('2011-12-31 00:00:00');
+    expect(dt.toString()).toEqual('2011-12-31T00:00:00.000');
     expect(dt.getTime()).toEqual(t);
   });
 

--- a/spec/tz.default.spec.js
+++ b/spec/tz.default.spec.js
@@ -12,4 +12,11 @@ describe('TimezoneJS', function () {
     expect(sampleTz).toBeDefined();
     expect(sampleTz.tzAbbr).toEqual('ICT');
   });
+
+  it('should load an unloaded zone file linked from the backward file', function () {
+    sampleTz = timezoneJS.timezone.getTzInfo(new Date(), 'Antarctica/South_Pole');
+    expect(timezoneJS.timezone.loadedZones).toEqual({ asia: true, antarctica: true, backward: true, australasia: true });
+    expect(sampleTz.tzAbbr).toEqual('NZDT');
+  });
+
 });

--- a/src/date.js
+++ b/src/date.js
@@ -55,7 +55,7 @@
     root.timezoneJS = timezoneJS;
   }
 
-  timezoneJS.VERSION = '0.4.13';
+  timezoneJS.VERSION = '0.4.13-1';
 
   // Grab the ajax library from global context.
   // This can be jQuery, Zepto or fleegix.

--- a/src/date.js
+++ b/src/date.js
@@ -196,12 +196,14 @@
     });
   };
 
-  // Constructor, which is similar to that of the native Date object itself
-  timezoneJS.Date = function () {
+// Constructor, which is similar to that of the native Date object itself
+timezoneJS.Date = function () {
     if(this === timezoneJS) {
-      throw 'timezoneJS.Date object must be constructed with \'new\'';
+        throw 'timezoneJS.Date object must be constructed with \'new\'';
     }
-    var args = Array.prototype.slice.apply(arguments)
+    var args = Array.prototype.slice.apply(arguments).filter(function(arg){
+        return arg !== null && arg !== undefined;
+    })
     , dt = null
     , tz = null
     , arr = []
@@ -225,52 +227,48 @@
     //
     //If 1st argument is an array, we can use it as a list of arguments itself
     if (Object.prototype.toString.call(args[0]) === '[object Array]') {
-      args = args[0];
+        args = args[0];
     }
     // If the last string argument doesn't parse as a Date, treat it as tz
     if (typeof args[args.length - 1] === 'string') {
-      valid = Date.parse(args[args.length - 1].replace(/GMT[\+\-]\d+/, ''));
-      if (isNaN(valid) || valid === null) {  // Checking against null is required for compatability with Datejs
-        tz = args.pop();
-      }
+        valid = Date.parse(args[args.length - 1].replace(/GMT[\+\-]\d+/, ''));
+        if (isNaN(valid) || valid === null) {  // Checking against null is required for compatability with Datejs
+            tz = args.pop();
+        }
     }
     var is_dt_local = false;
     switch (args.length) {
-      case 0:
-        dt = new Date();
-        break;
-      case 1:
-        dt = new Date(args[0]);
-        // Date strings are local if they do not contain 'Z', 'T' or timezone offsets like '+0200'
-        //  - more info below
-        if (typeof args[0] == 'string' && args[0].search(/[+-][0-9]{4}/) == -1
-                && args[0].search(/Z/) == -1 && args[0].search(/T/) == -1) {
+        case 0:
+            dt = new Date();
+            break;
+        case 1:
+            dt = new Date(args[0]);
+            // Date strings are local if they do not contain 'Z', 'T' or timezone offsets like '+0200'
+            //  - more info below
+/*            if (typeof args[0] == 'string' && args[0].search(/[+-][0-9]{4}/) == -1
+            && args[0].search(/Z/) == -1 && args[0].search(/T/) == -1) {
+                is_dt_local = true;
+            }*/
+            break;
+        case 2:
+            dt = new Date(args[0], args[1]);
             is_dt_local = true;
-        }
-        break;
-      case 2:
-        dt = new Date(args[0], args[1]);
-        is_dt_local = true;
-        break;
-      default:
-        for (var i = 0; i < 7; i++) {
-          arr[i] = args[i] || 0;
-        }
-        dt = new Date(arr[0], arr[1], arr[2], arr[3], arr[4], arr[5], arr[6]);
-        is_dt_local = true;
-        break;
+            break;
+        default:
+            for (var i = 0; i < 7; i++) {
+                arr[i] = args[i] || 0;
+            }
+            dt = new Date(arr[0], arr[1], arr[2], arr[3], arr[4], arr[5], arr[6]);
+            is_dt_local = true;
+            break;
+    }
+
+    if (isNaN(dt.getTime())) { // invalid date were passed
+        throw new Error('Invalid date');
     }
 
     this._useCache = false;
     this._tzInfo = {};
-    this._day = 0;
-    this.year = 0;
-    this.month = 0;
-    this.date = 0;
-    this.hours = 0;
-    this.minutes = 0;
-    this.seconds = 0;
-    this.milliseconds = 0;
     this.timezone = tz || null;
     // Tricky part:
     // The date is either given as unambiguous UTC date or otherwise the date is assumed
@@ -287,212 +285,181 @@
     // `dt_str_tz` is a date string containing timezone information, i.e. containing 'Z', 'T' or
     // /[+-][0-9]{4}/ (e.g. '+0200'), while `dt_str` is a string which does not contain
     // timezone information. See: http://dygraphs.com/date-formats.html
-    if (is_dt_local) {
-       this.setFromDateObjProxy(dt);
-    } else {
-       this.setFromTimeProxy(dt.getTime(), tz);
-    }
-  };
+    if (is_dt_local) setFromDate(this, null, dt);
+    else setFromDate(this, dt);
+};
+
+timezoneJS.Date.now = function(tz){
+    if (tz) return new timezoneJS.Date(tz);
+    else return new timezoneJS.Date();
+};
 
   // Implements most of the native Date object
-  timezoneJS.Date.prototype = {
-    getDate: function () { return this.date; },
-    getDay: function () { return this._day; },
-    getFullYear: function () { return this.year; },
-    getMonth: function () { return this.month; },
-    getYear: function () { return this.year - 1900; },
-    getHours: function () { return this.hours; },
-    getMilliseconds: function () { return this.milliseconds; },
-    getMinutes: function () { return this.minutes; },
-    getSeconds: function () { return this.seconds; },
-    getUTCDate: function () { return this.getUTCDateProxy().getUTCDate(); },
-    getUTCDay: function () { return this.getUTCDateProxy().getUTCDay(); },
-    getUTCFullYear: function () { return this.getUTCDateProxy().getUTCFullYear(); },
-    getUTCHours: function () { return this.getUTCDateProxy().getUTCHours(); },
-    getUTCMilliseconds: function () { return this.getUTCDateProxy().getUTCMilliseconds(); },
-    getUTCMinutes: function () { return this.getUTCDateProxy().getUTCMinutes(); },
-    getUTCMonth: function () { return this.getUTCDateProxy().getUTCMonth(); },
-    getUTCSeconds: function () { return this.getUTCDateProxy().getUTCSeconds(); },
+timezoneJS.Date.prototype = {
+    getDate: function () { return getLocal(this).getUTCDate(); },
+    getDay: function () { return getLocal(this).getUTCDay(); },
+    getFullYear: function () { return getLocal(this).getUTCFullYear(); },
+    getMonth: function () { return getLocal(this).getUTCMonth(); },
+    getYear: function () { return getLocal(this).getUTCFullYear() - 1900; },
+    getHours: function () { return getLocal(this).getUTCHours(); },
+    getMilliseconds: function () { return getLocal(this).getUTCMilliseconds(); },
+    getMinutes: function () { return getLocal(this).getUTCMinutes(); },
+    getSeconds: function () { return getLocal(this).getUTCSeconds(); },
+    getUTCDate: function () { return this._utc.getUTCDate(); },
+    getUTCDay: function () { return this._utc.getUTCDay(); },
+    getUTCFullYear: function () { return this._utc.getUTCFullYear(); },
+    getUTCYear: function () { return this._utc.getUTCFullYear() - 1900; },
+    getUTCHours: function () { return this._utc.getUTCHours(); },
+    getUTCMilliseconds: function () { return this._utc.getUTCMilliseconds(); },
+    getUTCMinutes: function () { return this._utc.getUTCMinutes(); },
+    getUTCMonth: function () { return this._utc.getUTCMonth(); },
+    getUTCSeconds: function () { return this._utc.getUTCSeconds(); },
     // Time adjusted to user-specified timezone
     getTime: function () {
-      return this._timeProxy + (this.getTimezoneOffset() * 60 * 1000);
+        return this._utc.getTime();
     },
     getTimezone: function () { return this.timezone; },
     getTimezoneOffset: function () { return this.getTimezoneInfo().tzOffset; },
     getTimezoneAbbreviation: function () { return this.getTimezoneInfo().tzAbbr; },
     getTimezoneInfo: function () {
-      if (this._useCache) return this._tzInfo;
-      var res;
-      // If timezone is specified, get the correct timezone info based on the Date given
-      if (this.timezone) {
-        res = this.timezone === 'Etc/UTC' || this.timezone === 'Etc/GMT'
-          ? { tzOffset: 0, tzAbbr: 'UTC' }
-          : timezoneJS.timezone.getTzInfo(this._timeProxy, this.timezone);
-      }
-      // If no timezone was specified, use the local browser offset
-      else {
-        res = { tzOffset: this.getLocalOffset(), tzAbbr: null };
-      }
-      this._tzInfo = res;
-      this._useCache = true;
-      return res;
-    },
-    getUTCDateProxy: function () {
-      var dt = new Date(this._timeProxy);
-      dt.setUTCMinutes(dt.getUTCMinutes() + this.getTimezoneOffset());
-      return dt;
+        if (this._useCache) return this._tzInfo;
+        var res;
+        // If timezone is specified, get the correct timezone info based on the Date given
+        if (this.timezone) {
+            res = this.timezone === 'Etc/UTC' || this.timezone === 'Etc/GMT'
+            ? { tzOffset: 0, tzAbbr: 'UTC' }
+            : timezoneJS.timezone.getTzInfo(this._utc.getTime(), this.timezone, true);
+        }
+        // If no timezone was specified, use the local browser offset
+        else {
+            res = { tzOffset: this._utc.getTimezoneOffset(), tzAbbr: getLocalAbbr(this._utc) };
+        }
+        this._tzInfo = res;
+        this._useCache = true;
+        return res;
     },
     setDate: function (date) {
-      this.setAttribute('date', date);
-      return this.getTime();
+        setAttribute(this,'date', date);
+        return this.getTime();
     },
     setFullYear: function (year, month, date) {
-      if (date !== undefined) { this.setAttribute('date', 1); }
-      this.setAttribute('year', year);
-      if (month !== undefined) { this.setAttribute('month', month); }
-      if (date !== undefined) { this.setAttribute('date', date); }
-      return this.getTime();
+        setAttribute(this,'year', year);
+        if (month !== undefined) { setAttribute(this,'month', month); }
+        if (date !== undefined) { setAttribute(this,'date', date); }
+        return this.getTime();
     },
     setMonth: function (month, date) {
-      this.setAttribute('month', month);
-      if (date !== undefined) { this.setAttribute('date', date); }
-      return this.getTime();
+        setAttribute(this,'month', month);
+        if (date !== undefined) { setAttribute(this,'date', date); }
+        return this.getTime();
     },
     setYear: function (year) {
-      year = Number(year);
-      if (0 <= year && year <= 99) { year += 1900; }
-      this.setUTCAttribute('year', year);
-      return this.getTime();
+        year = Number(year);
+        if (0 <= year && year <= 99) { year += 1900; }
+        setAttribute(this,'year', year);
+        return this.getTime();
     },
     setHours: function (hours, minutes, seconds, milliseconds) {
-      this.setAttribute('hours', hours);
-      if (minutes !== undefined) { this.setAttribute('minutes', minutes); }
-      if (seconds !== undefined) { this.setAttribute('seconds', seconds); }
-      if (milliseconds !== undefined) { this.setAttribute('milliseconds', milliseconds); }
-      return this.getTime();
+        setAttribute(this,'hours', hours);
+        if (minutes !== undefined) { setAttribute(this,'minutes', minutes); }
+        if (seconds !== undefined) { setAttribute(this,'seconds', seconds); }
+        if (milliseconds !== undefined) { setAttribute(this,'milliseconds', milliseconds); }
+        return this.getTime();
     },
     setMinutes: function (minutes, seconds, milliseconds) {
-      this.setAttribute('minutes', minutes);
-      if (seconds !== undefined) { this.setAttribute('seconds', seconds); }
-      if (milliseconds !== undefined) { this.setAttribute('milliseconds', milliseconds); }
-      return this.getTime();
+        setAttribute(this,'minutes', minutes);
+        if (seconds !== undefined) { setAttribute(this,'seconds', seconds); }
+        if (milliseconds !== undefined) { setAttribute(this,'milliseconds', milliseconds); }
+        return this.getTime();
     },
     setSeconds: function (seconds, milliseconds) {
-      this.setAttribute('seconds', seconds);
-      if (milliseconds !== undefined) { this.setAttribute('milliseconds', milliseconds); }
-      return this.getTime();
+        setAttribute(this,'seconds', seconds);
+        if (milliseconds !== undefined) { setAttribute(this,'milliseconds', milliseconds); }
+        return this.getTime();
     },
     setMilliseconds: function (milliseconds) {
-      this.setAttribute('milliseconds', milliseconds);
-      return this.getTime();
+        setAttribute(this,'milliseconds', milliseconds);
+        return this.getTime();
     },
     setTime: function (n) {
-      if (isNaN(n)) { throw new Error('Units must be a number.'); }
-      this.setFromTimeProxy(n, this.timezone);
-      return this.getTime();
+        if (isNaN(n)) { throw new Error('Units must be a number.'); }
+        setFromDate(this, new Date(n));
+        return this.getTime();
     },
     setUTCFullYear: function (year, month, date) {
-      if (date !== undefined) { this.setUTCAttribute('date', 1); }
-      this.setUTCAttribute('year', year);
-      if (month !== undefined) { this.setUTCAttribute('month', month); }
-      if (date !== undefined) { this.setUTCAttribute('date', date); }
-      return this.getTime();
+        setUTCAttribute(this,'year', year);
+        if (month !== undefined) { setUTCAttribute(this,'month', month); }
+        if (date !== undefined) { setUTCAttribute(this,'date', date); }
+        return this.getTime();
+    },
+    setUTCYear: function (year) {
+        year = Number(year);
+        if (0 <= year && year <= 99) { year += 1900; }
+        setUTCAttribute(this,'year', year);
+        return this.getTime();
     },
     setUTCMonth: function (month, date) {
-      this.setUTCAttribute('month', month);
-      if (date !== undefined) { this.setUTCAttribute('date', date); }
-      return this.getTime();
+        setUTCAttribute(this,'month', month);
+        if (date !== undefined) { setUTCAttribute(this,'date', date); }
+        return this.getTime();
     },
     setUTCDate: function (date) {
-      this.setUTCAttribute('date', date);
-      return this.getTime();
+        setUTCAttribute(this,'date', date);
+        return this.getTime();
     },
     setUTCHours: function (hours, minutes, seconds, milliseconds) {
-      this.setUTCAttribute('hours', hours);
-      if (minutes !== undefined) { this.setUTCAttribute('minutes', minutes); }
-      if (seconds !== undefined) { this.setUTCAttribute('seconds', seconds); }
-      if (milliseconds !== undefined) { this.setUTCAttribute('milliseconds', milliseconds); }
-      return this.getTime();
+        setUTCAttribute(this,'hours', hours);
+        if (minutes !== undefined) { setUTCAttribute(this,'minutes', minutes); }
+        if (seconds !== undefined) { setUTCAttribute(this,'seconds', seconds); }
+        if (milliseconds !== undefined) { setUTCAttribute(this,'milliseconds', milliseconds); }
+        return this.getTime();
     },
     setUTCMinutes: function (minutes, seconds, milliseconds) {
-      this.setUTCAttribute('minutes', minutes);
-      if (seconds !== undefined) { this.setUTCAttribute('seconds', seconds); }
-      if (milliseconds !== undefined) { this.setUTCAttribute('milliseconds', milliseconds); }
-      return this.getTime();
+        setUTCAttribute(this,'minutes', minutes);
+        if (seconds !== undefined) { setUTCAttribute(this,'seconds', seconds); }
+        if (milliseconds !== undefined) { setUTCAttribute(this,'milliseconds', milliseconds); }
+        return this.getTime();
     },
     setUTCSeconds: function (seconds, milliseconds) {
-      this.setUTCAttribute('seconds', seconds);
-      if (milliseconds !== undefined) { this.setUTCAttribute('milliseconds', milliseconds); }
-      return this.getTime();
+        setUTCAttribute(this,'seconds', seconds);
+        if (milliseconds !== undefined) { setUTCAttribute(this,'milliseconds', milliseconds); }
+        return this.getTime();
     },
     setUTCMilliseconds: function (milliseconds) {
-      this.setUTCAttribute('milliseconds', milliseconds);
-      return this.getTime();
-    },
-    setFromDateObjProxy: function (dt) {
-      this.year = dt.getFullYear();
-      this.month = dt.getMonth();
-      this.date = dt.getDate();
-      this.hours = dt.getHours();
-      this.minutes = dt.getMinutes();
-      this.seconds = dt.getSeconds();
-      this.milliseconds = dt.getMilliseconds();
-      this._day = dt.getDay();
-      this._dateProxy = dt;
-      this._timeProxy = Date.UTC(this.year, this.month, this.date, this.hours, this.minutes, this.seconds, this.milliseconds);
-      this._useCache = false;
-    },
-    setFromTimeProxy: function (utcMillis, tz) {
-      var dt = new Date(utcMillis);
-      var tzOffset = tz ? timezoneJS.timezone.getTzInfo(utcMillis, tz, true).tzOffset : dt.getTimezoneOffset();
-      dt.setTime(utcMillis + (dt.getTimezoneOffset() - tzOffset) * 60000);
-      this.setFromDateObjProxy(dt);
-    },
-    setAttribute: function (unit, n) {
-      if (isNaN(n)) { throw new Error('Units must be a number.'); }
-      var dt = this._dateProxy;
-      var meth = unit === 'year' ? 'FullYear' : unit.substr(0, 1).toUpperCase() + unit.substr(1);
-      dt['set' + meth](n);
-      this.setFromDateObjProxy(dt);
-    },
-    setUTCAttribute: function (unit, n) {
-      if (isNaN(n)) { throw new Error('Units must be a number.'); }
-      var meth = unit === 'year' ? 'FullYear' : unit.substr(0, 1).toUpperCase() + unit.substr(1);
-      var dt = this.getUTCDateProxy();
-      dt['setUTC' + meth](n);
-      dt.setUTCMinutes(dt.getUTCMinutes() - this.getTimezoneOffset());
-      this.setFromTimeProxy(dt.getTime() + this.getTimezoneOffset() * 60000, this.timezone);
+        setUTCAttribute(this,'milliseconds', milliseconds);
+        return this.getTime();
     },
     setTimezone: function (tz) {
-      var previousOffset = this.getTimezoneInfo().tzOffset;
-      this.timezone = tz;
-      this._useCache = false;
-      // Set UTC minutes offsets by the delta of the two timezones
-      this.setUTCMinutes(this.getUTCMinutes() - this.getTimezoneInfo().tzOffset + previousOffset);
+        this.timezone = tz;
+        this._useCache = false;
+        delete this._local;
     },
     removeTimezone: function () {
-      this.timezone = null;
-      this._useCache = false;
+        this.timezone = null;
+        this._useCache = false;
+        delete this._local;
     },
     valueOf: function () { return this.getTime(); },
     clone: function () {
-      return this.timezone ? new timezoneJS.Date(this.getTime(), this.timezone) : new timezoneJS.Date(this.getTime());
+        return this.timezone ? new timezoneJS.Date(this.getTime(), this.timezone) : new timezoneJS.Date(this.getTime());
     },
-    toGMTString: function () { return this.toString('EEE, dd MMM yyyy HH:mm:ss Z', 'Etc/GMT'); },
-    toLocaleString: function () {},
-    toLocaleDateString: function () {},
-    toLocaleTimeString: function () {},
+    toGMTString: function () { return this.toString('\\EEE, \\dd \\MMM \\yyyy \\HH:\\mm:\\ss \\Z', 'Etc/GMT'); },
+    toLocaleString: function () {throw new Error("not Implemented");},
+    toLocaleDateString: function () {throw new Error("not Implemented");},
+    toLocaleTimeString: function () {throw new Error("not Implemented");},
     toSource: function () {},
-    toISOString: function () { return this.toString('yyyy-MM-ddTHH:mm:ss.SSS', 'Etc/UTC') + 'Z'; },
+    toISOString: function () { return this.toString('\\yyyy-\\MM-\\ddT\\HH:\\mm:\\ss.\\SSS', 'Etc/UTC') + 'Z'; },
+    toLocalISOString : function () { return this.toString('\\yyyy-\\MM-\\ddT\\HH:\\mm:\\ss.\\SSS\\oo'); },
     toJSON: function () { return this.toISOString(); },
-    toDateString: function () { return this.toString('EEE MMM dd yyyy'); },
-    toTimeString: function () { return this.toString('H:mm k'); },
+    toDateString: function () { return this.toString('\\EEE \\MMM \\dd \\yyyy'); },
+    toTimeString: function () { return this.toString('\\H:\\mm \\k'); },
     // Allows different format following ISO8601 format:
     toString: function (format, tz) {
       // Default format is the same as toISOString
-      if (!format) format = 'yyyy-MM-dd HH:mm:ss';
+//      if (!format) format = 'yyyy-MM-ddTHH:mm:ss.SSS';
+      if (!format) format = '\\EEE \\MMM \\dd \\yyyy \\HH:\\mm:\\ss \\OO (\\ZZ)';
       var result = format;
-      var tzInfo = tz ? timezoneJS.timezone.getTzInfo(this.getTime(), tz) : this.getTimezoneInfo();
+      var tzInfo = tz ? timezoneJS.timezone.getTzInfo(this.getTime(), tz, true) : this.getTimezoneInfo();
       var _this = this;
       // If timezone is specified, get a clone of the current Date object and modify it
       if (tz) {
@@ -502,23 +469,23 @@
       var hours = _this.getHours();
       return result
       // fix the same characters in Month names
-      .replace(/a+/g, function () { return 'k'; })
+      .replace(/\\a+/g, function () { return 'k'; })
       // `y`: year
-      .replace(/y+/g, function (token) { return _fixWidth(_this.getFullYear(), token.length); })
+      .replace(/\\y+/g, function (token) { return _fixWidth(_this.getFullYear(), token.length-1); })
       // `d`: date
-      .replace(/d+/g, function (token) { return _fixWidth(_this.getDate(), token.length); })
+      .replace(/\\d+/g, function (token) { return _fixWidth(_this.getDate(), token.length-1); })
       // `m`: minute
-      .replace(/m+/g, function (token) { return _fixWidth(_this.getMinutes(), token.length); })
+      .replace(/\\m+/g, function (token) { return _fixWidth(_this.getMinutes(), token.length-1); })
       // `s`: second
-      .replace(/s+/g, function (token) { return _fixWidth(_this.getSeconds(), token.length); })
+      .replace(/\\s+/g, function (token) { return _fixWidth(_this.getSeconds(), token.length-1); })
       // `S`: millisecond
-      .replace(/S+/g, function (token) { return _fixWidth(_this.getMilliseconds(), token.length); })
+      .replace(/\\S+/g, function (token) { return _fixWidth(_this.getMilliseconds(), token.length-1); })
       // 'h': 12 hour format
-      .replace(/h+/g, function (token) { return _fixWidth( ((hours%12) === 0) ? 12 : (hours % 12), token.length); })
+      .replace(/\\h+/g, function (token) { return _fixWidth( ((hours%12) === 0) ? 12 : (hours % 12), token.length-1); })
       // `M`: month. Note: `MM` will be the numeric representation (e.g February is 02) but `MMM` will be text representation (e.g February is Feb)
-      .replace(/M+/g, function (token) {
+      .replace(/\\M+/g, function (token) {
         var _month = _this.getMonth(),
-        _len = token.length;
+        _len = token.length-1;
         if (_len > 3) {
           return timezoneJS.Months[_month];
         } else if (_len > 2) {
@@ -527,7 +494,7 @@
         return _fixWidth(_month + 1, _len);
       })
       // `k`: AM/PM
-      .replace(/k+/g, function () {
+      .replace(/\\k+/g, function () {
         if (hours >= 12) {
           if (hours > 12) {
             hours -= 12;
@@ -537,11 +504,13 @@
         return 'AM';
       })
       // `H`: hour
-      .replace(/H+/g, function (token) { return _fixWidth(hours, token.length); })
+      .replace(/\\H+/g, function (token) { return _fixWidth(hours, token.length-1); })
       // `E`: day
-      .replace(/E+/g, function (token) { return DAYS[_this.getDay()].substring(0, token.length); })
+      .replace(/\\E+/g, function (token) { return DAYS[_this.getDay()].substring(0, token.length-1); })
       // `Z`: timezone abbreviation
-      .replace(/Z+/gi, function () { return tzInfo.tzAbbr; });
+      .replace(/\\Z+/gi, function () { return tzInfo.tzAbbr; })
+      .replace(/\\O+/g, "GMT" + toIsoOffset(tzInfo.tzOffset).replace(/:/,""))
+      .replace(/\\o+/g, toIsoOffset(tzInfo.tzOffset));
     },
     toUTCString: function () { return this.toGMTString(); },
     civilToJulianDayNumber: function (y, m, d) {
@@ -562,10 +531,64 @@
         , jDt = Math.floor(365.25 * (y + 4716)) + Math.floor(30.6001 * (m + 1)) + d + b - 1524;
       return jDt;
     },
-    getLocalOffset: function () {
-      return this._dateProxy.getTimezoneOffset();
+};
+
+function getLocalAbbr(dt){
+    var m = dt.toString().match(/\((.*?)\)$/);
+    return m && m[1];
+}
+
+function toIsoOffset(offset){
+	return (offset>=0?"-":"+") + _fixWidth(Math.abs(offset/60),2) + ":" + _fixWidth(offset%60,2);
+}
+
+
+function setFromDate(that, utc, local){
+    delete that._local;
+    that._utc = utc;
+    if (!utc){
+        var localMSec = Date.UTC(local.getFullYear(), local.getMonth(), local.getDate(), local.getHours(), local.getMinutes(), local.getSeconds(), local.getMilliseconds());
+        var tzOffset = that.timezone ? timezoneJS.timezone.getTzInfo(localMSec, that.timezone).tzOffset : local.getTimezoneOffset();
+        that._utc = new Date(local.getTime() - (local.getTimezoneOffset() - tzOffset) * 60000);
     }
-  };
+    that._useCache = false;
+}
+
+function getLocal(that){
+    if (!that._local){
+        var tzOffset = that.timezone ? timezoneJS.timezone.getTzInfo(that._utc, that.timezone, true).tzOffset : that._utc.getTimezoneOffset();
+        that._local = new Date(that._utc.getTime() - tzOffset * 60000);
+    }
+    return that._local;
+}
+
+function setAttribute(that, unit, n) {
+    if (isNaN(n)) { throw new Error('Units must be a number.'); }
+//    console.log("setAttribute", unit, n);
+    var tzOffset = that.timezone ? timezoneJS.timezone.getTzInfo(that._utc, that.timezone, true).tzOffset : that._utc.getTimezoneOffset();
+    var dt = new Date(that._utc.getTime() + (that._utc.getTimezoneOffset() - tzOffset) * 60000);
+//    console.log("setAttribute1", dt, tzOffset, that._utc.getTimezoneOffset());
+    var startDiff = tzOffset - that._utc.getTimezoneOffset();
+    var startLocalUtc = dt.getTime();
+    var meth = unit === 'year' ? 'FullYear' : unit.substr(0, 1).toUpperCase() + unit.substr(1);
+    dt['set' + meth](n);
+//    console.log("setAttribute2", dt);
+    var endLocalUtc = dt.getTime();
+    var localMSec = Date.UTC(dt.getFullYear(), dt.getMonth(), dt.getDate(), dt.getHours(), dt.getMinutes(), dt.getSeconds(), dt.getMilliseconds());
+//    console.log("setAttribute3", dt, (that.timezone ? timezoneJS.timezone.getTzInfo(localMSec, that.timezone).tzOffset : dt.getTimezoneOffset()), dt.getTimezoneOffset());
+    var endDiff = (that.timezone ? timezoneJS.timezone.getTzInfo(localMSec, that.timezone).tzOffset : dt.getTimezoneOffset()) - dt.getTimezoneOffset();
+    dt.setTime(that._utc.getTime() + (endLocalUtc - startLocalUtc) + (startDiff - endDiff) * 60000);
+//    console.log("setAttribute4", dt);
+    setFromDate(that, dt);
+}
+
+function setUTCAttribute(that, unit, n) {
+    if (isNaN(n)) { throw new Error('Units must be a number.'); }
+    var meth = unit === 'year' ? 'FullYear' : unit.substr(0, 1).toUpperCase() + unit.substr(1);
+    var dt = that._utc;
+    dt['setUTC' + meth](n);
+    setFromDate(that, dt);
+}
 
 
   timezoneJS.timezone = new function () {


### PR DESCRIPTION
timezone.js doesn't handle daylight saving switches correct.
It stores the time as local time which isn't unique during daylight saving switch.
This changes fixes the problem and makes the interface more compatible to the original Date object.

This is a test example which doesn't work with the original module:
var date = new timezoneJS(2017,9,29,2,1,0,"Europe/Berlin");
var oldTime = date.getTime();
console.log(date.getTime());
console.log(date);
console.log(date.getUTCHours(), date.getUTCMinutes(), date.getTimezoneOffset());
console.log(date.getHours());
date.setUTCMinutes(date.getUTCMinutes() + 60);
console.log(date);
console.log(date.getUTCHours(), date.getUTCMinutes(), date.getTimezoneOffset());
console.log(date.getHours());
console.log((date.getTime() - oldTime)/1000/60);
